### PR TITLE
Add English translations for IO and end effector docs

### DIFF
--- a/en/xarm_python_sdk_docs/5.-IO.md
+++ b/en/xarm_python_sdk_docs/5.-IO.md
@@ -1,0 +1,128 @@
+# 5. IO
+
+## API List
+
+### IO
+The IO of the xArm series robots is divided into two parts: **controller box IO** and **robot arm IO**.
+
+| API Function | Description |
+| :--- | :--- |
+| `set_cgpio_digital()` | Set controller box digital IO output |
+| `get_cgpio_digital()` | Get controller box digital IO input |
+| `set_cgpio_analog()` | Set controller box analog IO output |
+| `get_cgpio_analog()` | Get controller box analog IO input |
+| `set_tgpio_digital()` | Set robot end digital IO output |
+| `get_tgpio_digital()` | Get robot end digital IO input |
+| `get_tgpio_analog()` | Get robot end analog input |
+| `set_cgpio_digital_input_function()` | Set controller box digital input function |
+| `set_cgpio_digital_output_function()` | Set controller box digital output function |
+
+### Controller Box IO
+The controller box IO is located on the controller and is usually used for signal interaction with external devices such as PLCs and sensors.
+
+#### Set Controller Box Digital Output
+Use `set_cgpio_digital(io_num, value)` to set the output level of a controller box digital IO port.
+
+- `io_num`: IO port number, range 0-15 (0-7 for Lite 6).
+- `value`: IO level, 0 for low, 1 for high.
+
+**Example:** Set controller IO 7 high.
+
+```python
+arm.set_cgpio_digital(7, 1)
+```
+
+#### Get Controller Box Digital Input
+Use `get_cgpio_digital()` to obtain the input levels of all controller box digital IO ports. The return value is a tuple containing the error code and IO values.
+
+**Example:** Get and print the status of all controller box digital inputs.
+
+```python
+code, digitals = arm.get_cgpio_digital()
+if code == 0:
+    print("Controller box digital input status:", digitals)
+```
+
+#### Set Controller Box Analog Output
+Use `set_cgpio_analog(io_num, value)` to set the value of a controller box analog IO.
+
+- `io_num`: Analog IO port number, typically 0 or 1.
+- `value`: Analog value to set, range 0-10.0 (volts).
+
+**Example:** Set controller analog output CO0 to 5.0V.
+
+```python
+arm.set_cgpio_analog(0, 5.0)
+```
+
+#### Get Controller Box Analog Input
+Use `get_cgpio_analog()` to get the value of a controller box analog IO.
+
+- `io_num`: Analog IO port number, 0 or 1.
+
+**Example:** Get the value of controller analog input CI0.
+
+```python
+code, analog_val = arm.get_cgpio_analog(0)
+if code == 0:
+    print("Controller box analog input 0 value:", analog_val)
+```
+
+### Robot Arm IO
+The robot arm IO (tool IO) functions and APIs are similar to the controller box IO:
+
+| IO Type | API Function | Description |
+| :--- | :--- | :--- |
+| Digital Output (DO) | `set_tgpio_digital()` | Set tool digital output level |
+| Digital Input (DI) | `get_tgpio_digital()` | Get tool digital input level |
+| Analog Input (AI) | `get_tgpio_analog()` | Get tool analog input value |
+
+#### Set Controller Box Digital Input Function
+Use `set_cgpio_digital_input_function(ionum, fun)` to configure the function of a controller box digital input port.
+
+- `ionum`: IO port number, range 0-15.
+- `fun`: Function mode:
+    - `0`: General Input
+    - `1`: Stop Motion
+    - `2`: Protection Reset
+    - `11`: Offline Task
+    - `12`: Manual Mode
+    - `13`: Reduced Mode
+    - `14`: Enable Robot
+
+**Example:** Configure digital input `CI0` to stop motion. When `CI0` receives a signal, the robot stops immediately and clears buffered commands, equivalent to `set_state(4)` without cutting power.
+
+```python
+# Configure CI0 (ionum=0) as external emergency stop (fun=1)
+arm.set_cgpio_digital_input_function(0, 1)
+
+# Restore CI0 to general input
+arm.set_cgpio_digital_input_function(0, 0)
+```
+
+#### Set Controller Box Digital Output Function
+Use `set_cgpio_digital_output_function(ionum, fun)` to configure the function of a controller box digital output port.
+
+- `ionum`: IO port number, 0-7 for CO0~CO7 and 8-15 for DO0~DO7.
+- `fun`: Function mode:
+    - `0`: General Output
+    - `1`: Motion Stop
+    - `2`: Moving
+    - `11`: Has Error
+    - `12`: Has Warn
+    - `13`: Collision
+    - `14`: In Manual Mode
+    - `15`: In Offline Task
+    - `16`: In Reduced Mode
+    - `17`: Robot Is Enabled
+    - `18`: Emergency Stop is Pressed
+
+**Example:** Configure digital output `CO0` to indicate a robot error. When the robot reports an error, `CO0` outputs high level.
+
+```python
+# Configure CO0 (ionum=0) to indicate error state (fun=11)
+arm.set_cgpio_digital_output_function(0, 11)
+
+# Restore CO0 to general output
+arm.set_cgpio_digital_output_function(0, 0)
+```

--- a/en/xarm_python_sdk_docs/6.-End-effectors.md
+++ b/en/xarm_python_sdk_docs/6.-End-effectors.md
@@ -1,0 +1,127 @@
+# 6. End Effectors
+
+## API List
+
+### Vacuum Gripper
+
+| API Function | Description |
+| :--- | :--- |
+| `set_vacuum_gripper()` | Set vacuum gripper to pick or release |
+| `get_vacuum_gripper()` | Get vacuum gripper state |
+
+### UFACTORY Gripper
+
+| API Function | Description |
+| :--- | :--- |
+| `set_gripper_enable()` | Enable the gripper |
+| `set_gripper_speed()` | Set gripper speed |
+| `set_gripper_position()` | Control gripper position |
+| `get_gripper_position()` | Get current gripper position |
+| `get_gripper_err_code()` | Get gripper error code |
+| `clean_gripper_error()` | Clear gripper error |
+
+### BIO Gripper
+
+| API Function | Description |
+| :--- | :--- |
+| `set_bio_gripper_enable()` | Enable BIO gripper |
+| `set_bio_gripper_speed()` | Set BIO gripper speed |
+| `open_bio_gripper()` | Open BIO gripper |
+| `close_bio_gripper()` | Close BIO gripper |
+| `get_bio_gripper_status()` | Get BIO gripper status |
+| `get_bio_gripper_error()` | Get BIO gripper error code |
+| `clean_bio_gripper_error()` | Clear BIO gripper error |
+
+### Robotiq Gripper (2F-85 and 2F-140)
+
+| API Function | Description |
+| :--- | :--- |
+| `set_robotiq_gripper_enable()` | Enable Robotiq gripper |
+| `set_robotiq_gripper_speed()` | Set Robotiq gripper speed |
+| `set_robotiq_gripper_force()` | Set Robotiq gripper force |
+| `open_robotiq_gripper()` | Open Robotiq gripper |
+| `close_robotiq_gripper()` | Close Robotiq gripper |
+| `get_robotiq_gripper_status()` | Get Robotiq gripper status |
+
+## End Effector Control
+
+### Vacuum Gripper
+
+#### Set Vacuum Gripper State
+Use `set_vacuum_gripper(on, wait=False, timeout=3, hardware_version=1)` to set the vacuum gripper to pick or release.
+
+- `on`: `True` to pick, `False` to release.
+- `wait`: Whether to wait for the picking result. Default is `False`. If `True`, the program blocks until the pick succeeds or times out.
+- `timeout`: Timeout in seconds, default is 3. Takes effect when `wait=True`. If picking fails within the specified time (determined by the vacuum gripper's built-in pressure sensor), the SDK returns error code `41`.
+- `hardware_version`: Hardware version.
+    - `1`: Aviation connector (default)
+    - `2`: PIN contact connector
+
+**Example:**
+
+```python
+# Simply turn on and off
+arm.set_vacuum_gripper(True)   # Pick
+time.sleep(2)
+arm.set_vacuum_gripper(False)  # Release
+
+# Wait for the result, up to 3 seconds
+code = arm.set_vacuum_gripper(True, wait=True, timeout=3)
+if code == 0:
+    print("Picked successfully")
+else:
+    print(f"Pick failed, code: {code}")
+```
+
+#### Get Vacuum Gripper State
+Use `get_vacuum_gripper()` to get the current state of the vacuum gripper.
+
+- `hardware_version`: Hardware version
+    - `1`: Aviation connector (default)
+    - `2`: PIN contact connector
+- **Return Value:** A tuple containing the error code and state.
+    - `code`: API return code
+    - `state`: Gripper state
+        - `0`: Off
+        - `1`: On
+
+**Example:**
+
+```python
+code, state = arm.get_vacuum_gripper()
+if code == 0:
+    if state == 1:
+        print("Vacuum gripper is on")
+    else:
+        print("Vacuum gripper is off")
+```
+
+### UFACTORY Gripper
+
+#### Enable Gripper
+Enable the gripper before use.
+
+```python
+# Enable gripper
+arm.set_gripper_enable(True)
+```
+
+#### Set Gripper Speed
+Set the opening/closing speed of the gripper.
+
+```python
+# Set gripper speed to 2000
+arm.set_gripper_speed(2000)
+```
+
+#### Control Gripper Position
+The position range is -10 to 850.
+
+```python
+# Open the gripper (fully open)
+arm.set_gripper_position(850, wait=True)
+
+# Close the gripper
+arm.set_gripper_position(0, wait=True)
+```
+`wait=True` means the program waits for the gripper to reach the position before executing the next command.


### PR DESCRIPTION
## Summary
- add English version of IO section
- add English version of end effectors section

## Testing
- `npm run docs:build` *(fails: vitepress not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e1d653ab083339de365acb59bb485